### PR TITLE
refactor: alert context and product/order service imports

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { Search, Bell, Users, ThumbsUp, ShoppingCart, Package, HelpCircle, Loader2 } from 'lucide-react';
-import { useAlert } from '@/lib/context/alert-context';
+import { useAlert } from '@/providers/alert-provider';
 import { getDashboardStats, getTopProducts, getReviewStats, getQuarterlySales } from '@/lib/supabase';
 import React from 'react';
 

--- a/src/app/admin/orders/[id]/page.tsx
+++ b/src/app/admin/orders/[id]/page.tsx
@@ -21,12 +21,12 @@ import {
 import Link from 'next/link';
 import Image from 'next/image';
 import { useParams, useRouter } from 'next/navigation';
-import { useAlert } from '@/lib/context/alert-context';
+import { useAlert } from '@/providers/alert-provider';
 import { getOrderById, updateOrderStatus } from '@/lib/supabase';
 
 // Define interfaces for order data
 interface OrderItem {
-    id: number;
+    id: string;
     name: string;
     sku: string;
     price: string;
@@ -64,7 +64,7 @@ interface PaymentDetails {
 }
 
 interface OrderData {
-    id: number;
+    id: string;
     orderNumber: string;
     customer: CustomerInfo;
     date: string;
@@ -112,7 +112,7 @@ const StatusBadge = ({ status }: { status: string }) => {
 
 export default function OrderDetailPage() {
     const params = useParams();
-    const orderId = typeof params.id === 'string' ? parseInt(params.id, 10) : 0;
+    const orderId = typeof params.id === 'string' ? params.id : '';
     const router = useRouter();
     const { showAlert } = useAlert();
     const [isLoading, setIsLoading] = useState(true);
@@ -130,19 +130,19 @@ export default function OrderDetailPage() {
             try {
                 setIsLoading(true);
                 const { data, error } = await getOrderById(orderId);
-                
+
                 if (error) {
                     throw new Error(error.message);
                 }
-                
+
                 if (data) {
                     // Format the order data for display
                     const orderDate = new Date(data.order.order_date);
                     const formattedDate = orderDate.toISOString().split('T')[0];
                     const formattedTime = orderDate.toTimeString().split(' ')[0].substring(0, 5);
-                    
+
                     // Transform order items
-                    const items = data.orderItems ? data.orderItems.map((item: { order_item_id: number; product_id: number; products?: { name: string; image: string }; unit_price: number; quantity: number; subtotal: number; }) => ({
+                    const items = data.orderItems ? data.orderItems.map((item: { order_item_id: string; product_id: string; products?: { name: string; image: string }; unit_price: number; quantity: number; subtotal: number; }) => ({
                         id: item.order_item_id,
                         name: item.products?.name || `Product #${item.product_id}`,
                         sku: `SKU-${item.product_id}`,
@@ -151,7 +151,7 @@ export default function OrderDetailPage() {
                         total: `$${item.subtotal.toFixed(2)}`,
                         image: item.products?.image || '/placeholder.jpg'
                     })) : [];
-                    
+
                     // Create formatted order object
                     const formattedOrder: OrderData = {
                         id: data.order.order_id,
@@ -187,15 +187,15 @@ export default function OrderDetailPage() {
                         total: `$${data.order.total_amount.toFixed(2)}`,
                         notes: '',
                         history: [
-                            { 
-                                date: formattedDate, 
-                                time: formattedTime, 
-                                status: 'Order Placed', 
-                                description: 'Order was placed by customer' 
+                            {
+                                date: formattedDate,
+                                time: formattedTime,
+                                status: 'Order Placed',
+                                description: 'Order was placed by customer'
                             }
                         ]
                     };
-                    
+
                     setOrderData(formattedOrder);
                 }
             } catch (err) {
@@ -205,27 +205,27 @@ export default function OrderDetailPage() {
                 setIsLoading(false);
             }
         };
-        
+
         fetchOrder();
     }, [orderId, showAlert]);
 
     const handleStatusChange = async (newStatus: string) => {
         try {
             setIsStatusDropdownOpen(false);
-            
+
             // Update status in Supabase
             const { error } = await updateOrderStatus(orderId, newStatus.toLowerCase());
-            
+
             if (error) {
                 throw new Error(error.message);
             }
-            
+
             // Update local state
             if (orderData) {
                 const now = new Date();
                 const date = now.toISOString().split('T')[0];
                 const time = now.toTimeString().split(' ')[0].substring(0, 5);
-                
+
                 // Add to history
                 const updatedHistory = [
                     ...orderData.history,
@@ -236,13 +236,13 @@ export default function OrderDetailPage() {
                         description: `Order status changed to ${newStatus}`
                     }
                 ];
-                
+
                 setOrderData({
                     ...orderData,
                     status: newStatus,
                     history: updatedHistory
                 });
-                
+
                 showAlert('success', `Order status updated to ${newStatus}`, 2000);
             }
         } catch (err) {
@@ -267,7 +267,7 @@ export default function OrderDetailPage() {
                 ...orderData,
                 notes: orderNote
             });
-            
+
             showAlert('success', 'Note added to order', 2000);
             setOrderNote('');
             setIsNoteExpanded(false);
@@ -291,11 +291,11 @@ export default function OrderDetailPage() {
                         Back to Orders
                     </Link>
                 </div>
-                
+
                 <div className="bg-white rounded-lg shadow-md p-8 text-center">
                     <h2 className="text-xl font-medium text-gray-900 mb-2">Order not found</h2>
                     <p className="text-gray-500 mb-6">The order you&apos;re looking for doesn&apos;t exist or has been removed.</p>
-                    <button 
+                    <button
                         onClick={() => router.push('/admin/orders')}
                         className="px-4 py-2 bg-amber-500 text-white rounded-md hover:bg-amber-600"
                     >

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { Search, Filter, Eye, FileText, Download, Calendar, Clock, ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
 import Link from 'next/link';
-import { useAlert } from '@/lib/context/alert-context';
+import { useAlert } from '@/providers/alert-provider';
 import { getOrders } from '@/lib/supabase';
 
 // Define interfaces for order data

--- a/src/app/admin/products/[id]/page.tsx
+++ b/src/app/admin/products/[id]/page.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 import { ArrowLeft, Edit, Trash2, Star, Package, DollarSign, Tag, Truck } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { useAlert } from '@/lib/context/alert-context';
+import { useAlert } from '@/providers/alert-provider';
 
 export default function ProductDetailPage() {
     const { id } = useParams();
@@ -13,7 +13,7 @@ export default function ProductDetailPage() {
     const { showAlert } = useAlert();
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
-    
+
     // Mock product data - in a real app, this would come from an API
     const product = {
         id: Number(id),
@@ -38,30 +38,30 @@ export default function ProductDetailPage() {
         sales: 156,
         reviews: 48
     };
-    
+
     useEffect(() => {
         // Simulate API call
         const timer = setTimeout(() => {
             setIsLoading(false);
         }, 800);
-        
+
         return () => clearTimeout(timer);
     }, []);
-    
+
     const handleDelete = () => {
         // Close modal
         setIsDeleteModalOpen(false);
-        
+
         // Show loading state
         showAlert('info', 'Deleting product...', 1000);
-        
+
         // Simulate API call
         setTimeout(() => {
             showAlert('success', `Product "${product.name}" has been deleted`, 3000);
             router.push('/admin/products');
         }, 1500);
     };
-    
+
     if (isLoading) {
         return (
             <div className="flex items-center justify-center h-screen">
@@ -73,7 +73,7 @@ export default function ProductDetailPage() {
             </div>
         );
     }
-    
+
     return (
         <div className="p-6">
             <div className="mb-6">
@@ -82,10 +82,10 @@ export default function ProductDetailPage() {
                     Back to Products
                 </Link>
             </div>
-            
+
             <div className="flex justify-between items-center mb-6">
                 <h1 className="text-2xl font-bold">{product.name}</h1>
-                
+
                 <div className="flex space-x-3">
                     <Link href={`/admin/products/edit/${product.id}`}>
                         <motion.button
@@ -97,7 +97,7 @@ export default function ProductDetailPage() {
                             Edit Product
                         </motion.button>
                     </Link>
-                    
+
                     <motion.button
                         whileHover={{ scale: 1.05 }}
                         whileTap={{ scale: 0.95 }}
@@ -109,7 +109,7 @@ export default function ProductDetailPage() {
                     </motion.button>
                 </div>
             </div>
-            
+
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 {/* Product Image */}
                 <div className="bg-white rounded-lg shadow-md p-6">
@@ -118,26 +118,25 @@ export default function ProductDetailPage() {
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                         </svg>
                     </div>
-                    
+
                     <div className="flex justify-center">
-                        <span className={`px-3 py-1 rounded-full text-xs font-medium ${
-                            product.status === 'In Stock' 
-                                ? 'bg-green-100 text-green-800' 
+                        <span className={`px-3 py-1 rounded-full text-xs font-medium ${product.status === 'In Stock'
+                                ? 'bg-green-100 text-green-800'
                                 : product.status === 'Low Stock'
-                                ? 'bg-yellow-100 text-yellow-800'
-                                : 'bg-red-100 text-red-800'
-                        }`}>
+                                    ? 'bg-yellow-100 text-yellow-800'
+                                    : 'bg-red-100 text-red-800'
+                            }`}>
                             {product.status}
                         </span>
                     </div>
                 </div>
-                
+
                 {/* Product Details */}
                 <div className="bg-white rounded-lg shadow-md p-6 lg:col-span-2">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div>
                             <h2 className="text-lg font-semibold mb-4">Product Information</h2>
-                            
+
                             <div className="space-y-3">
                                 <div className="flex items-center">
                                     <Tag className="h-5 w-5 text-gray-400 mr-3" />
@@ -146,7 +145,7 @@ export default function ProductDetailPage() {
                                         <p className="font-medium">{product.category}</p>
                                     </div>
                                 </div>
-                                
+
                                 <div className="flex items-center">
                                     <DollarSign className="h-5 w-5 text-gray-400 mr-3" />
                                     <div>
@@ -154,7 +153,7 @@ export default function ProductDetailPage() {
                                         <p className="font-medium">{product.price}</p>
                                     </div>
                                 </div>
-                                
+
                                 <div className="flex items-center">
                                     <Package className="h-5 w-5 text-gray-400 mr-3" />
                                     <div>
@@ -162,7 +161,7 @@ export default function ProductDetailPage() {
                                         <p className="font-medium">{product.sku}</p>
                                     </div>
                                 </div>
-                                
+
                                 <div className="flex items-center">
                                     <Star className="h-5 w-5 text-gray-400 mr-3" />
                                     <div>
@@ -172,10 +171,10 @@ export default function ProductDetailPage() {
                                 </div>
                             </div>
                         </div>
-                        
+
                         <div>
                             <h2 className="text-lg font-semibold mb-4">Inventory</h2>
-                            
+
                             <div className="space-y-3">
                                 <div className="flex items-center">
                                     <Truck className="h-5 w-5 text-gray-400 mr-3" />
@@ -184,7 +183,7 @@ export default function ProductDetailPage() {
                                         <p className="font-medium">{product.stock} units</p>
                                     </div>
                                 </div>
-                                
+
                                 <div className="flex items-center">
                                     <div className="h-5 w-5 mr-3" /> {/* Spacer for alignment */}
                                     <div>
@@ -192,7 +191,7 @@ export default function ProductDetailPage() {
                                         <p className="font-medium">{product.weight}</p>
                                     </div>
                                 </div>
-                                
+
                                 <div className="flex items-center">
                                     <div className="h-5 w-5 mr-3" /> {/* Spacer for alignment */}
                                     <div>
@@ -200,7 +199,7 @@ export default function ProductDetailPage() {
                                         <p className="font-medium">{product.dimensions}</p>
                                     </div>
                                 </div>
-                                
+
                                 <div className="flex items-center">
                                     <div className="h-5 w-5 mr-3" /> {/* Spacer for alignment */}
                                     <div>
@@ -211,12 +210,12 @@ export default function ProductDetailPage() {
                             </div>
                         </div>
                     </div>
-                    
+
                     <div className="mt-6">
                         <h2 className="text-lg font-semibold mb-2">Description</h2>
                         <p className="text-gray-600">{product.description}</p>
                     </div>
-                    
+
                     <div className="mt-6">
                         <h2 className="text-lg font-semibold mb-2">Tags</h2>
                         <div className="flex flex-wrap gap-2">
@@ -228,11 +227,11 @@ export default function ProductDetailPage() {
                         </div>
                     </div>
                 </div>
-                
+
                 {/* Variants */}
                 <div className="bg-white rounded-lg shadow-md p-6 lg:col-span-3">
                     <h2 className="text-lg font-semibold mb-4">Product Variants</h2>
-                    
+
                     <div className="overflow-x-auto">
                         <table className="min-w-full">
                             <thead>
@@ -254,27 +253,27 @@ export default function ProductDetailPage() {
                         </table>
                     </div>
                 </div>
-                
+
                 {/* Additional Info */}
                 <div className="bg-white rounded-lg shadow-md p-6 lg:col-span-3">
                     <h2 className="text-lg font-semibold mb-4">Additional Information</h2>
-                    
+
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                         <div className="border rounded-md p-4">
                             <p className="text-sm text-gray-500">Date Added</p>
                             <p className="font-medium">{product.dateAdded}</p>
                         </div>
-                        
+
                         <div className="border rounded-md p-4">
                             <p className="text-sm text-gray-500">Last Updated</p>
                             <p className="font-medium">{product.lastUpdated}</p>
                         </div>
-                        
+
                         <div className="border rounded-md p-4">
                             <p className="text-sm text-gray-500">Product ID</p>
                             <p className="font-medium">{product.id}</p>
                         </div>
-                        
+
                         <div className="border rounded-md p-4">
                             <p className="text-sm text-gray-500">Total Variants</p>
                             <p className="font-medium">{product.variants.length}</p>
@@ -282,11 +281,11 @@ export default function ProductDetailPage() {
                     </div>
                 </div>
             </div>
-            
+
             {/* Delete Confirmation Modal */}
             {isDeleteModalOpen && (
                 <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                    <motion.div 
+                    <motion.div
                         className="bg-white rounded-lg p-6 w-full max-w-md"
                         initial={{ scale: 0.9, opacity: 0 }}
                         animate={{ scale: 1, opacity: 1 }}
@@ -294,10 +293,10 @@ export default function ProductDetailPage() {
                     >
                         <h2 className="text-xl font-bold mb-4">Delete Product</h2>
                         <p className="text-gray-600 mb-6">
-                            Are you sure you want to delete <span className="font-semibold">{product.name}</span>? 
+                            Are you sure you want to delete <span className="font-semibold">{product.name}</span>?
                             This action cannot be undone.
                         </p>
-                        
+
                         <div className="flex justify-end space-x-3">
                             <button
                                 className="px-4 py-2 border border-gray-300 rounded-md text-gray-700"
@@ -305,7 +304,7 @@ export default function ProductDetailPage() {
                             >
                                 Cancel
                             </button>
-                            
+
                             <motion.button
                                 whileHover={{ scale: 1.05 }}
                                 whileTap={{ scale: 0.95 }}

--- a/src/app/admin/products/add/page.tsx
+++ b/src/app/admin/products/add/page.tsx
@@ -4,10 +4,10 @@ import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowLeft, Upload, X, Loader2 } from 'lucide-react';
 import Link from 'next/link';
-import { useAlert } from '@/lib/context/alert-context';
+import { useAlert } from '@/providers/alert-provider';
 import { useRouter } from 'next/navigation';
-import { getCategories } from '@/lib/supabase/categories/categories.model';
-import { getSubcategories } from '@/lib/supabase/subcategories/subcategories.model';
+import { getCategories } from '@/lib/supabase/categories/category.service';
+import { getSubcategories } from '@/lib/supabase/subcategories/subcategory.service';
 
 interface Category {
     category_id: number;
@@ -486,3 +486,4 @@ export default function AddProductPage() {
         </div>
     );
 } 
+

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -3,10 +3,10 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Plus, Search, Trash2, Eye, RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react';
-import { useAlert } from '@/lib/context/alert-context';
+import { useAlert } from '@/providers/alert-provider';
 import Link from 'next/link';
 import Image from 'next/image';
-import { getProducts } from '@/lib/supabase/products/products.model';
+import { getProducts } from '@/lib/supabase/products/product.service';
 
 // Animation variants
 const containerVariants = {
@@ -594,3 +594,4 @@ export default function ProductsPage() {
         </div>
     );
 } 
+


### PR DESCRIPTION
Updated all admin pages to import useAlert from '@/providers/alert-provider' instead of the old context path. Changed product and order data service imports to use new service files (e.g., product.service, category.service, subcategory.service) for consistency and maintainability. Also updated type definitions for order and product IDs to use string instead of number where appropriate.