### PR TITLE
fix: Enable ThemeProvider and improve loading states

### DIFF
--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -5,7 +5,7 @@ import { AuthProvider } from './auth-provider';
 import { CartProvider } from './cart-provider';
 import { AlertProvider } from './alert-provider';
 import SupabaseProvider from './supabase-provider';
-// import { ThemeProvider } from './theme-provider';
+import { ThemeProvider } from './theme-provider';
 
 export function Providers({ children }: { children: React.ReactNode }) {
     return (
@@ -13,9 +13,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
             <AuthProvider>
                 <AlertProvider>
                     <CartProvider>
-                        {/* <ThemeProvider defaultTheme="light"> */}
-                        {children}
-                        {/* </ThemeProvider> */}
+                        <ThemeProvider defaultTheme="light">
+                            {children}
+                        </ThemeProvider>
                     </CartProvider>
                 </AlertProvider>
             </AuthProvider>

--- a/src/providers/supabase-provider.tsx
+++ b/src/providers/supabase-provider.tsx
@@ -41,14 +41,16 @@ export default function SupabaseProvider({
     };
   }, [supabase]);
 
-  // Don't render children until client is ready
-  if (!mounted || !supabase) {
-    return <>{children}</>;
-  }
-
+  // Always wrap children with Provider, but show loading state if not ready
   return (
     <Context.Provider value={{ supabase }}>
-      {children}
+      {!mounted || !supabase ? (
+        <div className="flex items-center justify-center min-h-screen">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
+        </div>
+      ) : (
+        children
+      )}
     </Context.Provider>
   );
 }

--- a/src/providers/theme-provider.tsx
+++ b/src/providers/theme-provider.tsx
@@ -72,14 +72,12 @@ export function ThemeProvider({
     setTheme,
   };
 
-  // Prevent flash of unstyled content
-  if (!mounted) {
-    return <>{children}</>;
-  }
-
+  // Always wrap with Provider, hide content until mounted to prevent FOUC
   return (
     <ThemeProviderContext.Provider value={value}>
-      {mounted ? <>{children}</> : <div style={{ visibility: 'hidden' }}>{children}</div>}
+      <div style={{ visibility: mounted ? 'visible' : 'hidden' }}>
+        {children}
+      </div>
     </ThemeProviderContext.Provider>
   );
 }


### PR DESCRIPTION
Uncomments and enables ThemeProvider in the Providers component. Updates SupabaseProvider to show a loading spinner until the client is ready. Refactors ThemeProvider to always wrap children and prevent flash of unstyled content by hiding content until mounted.