### PR TITLE
feat: Add authentication and role checks to order APIs

### DIFF
--- a/src/app/api/orders/[orderId]/route.ts
+++ b/src/app/api/orders/[orderId]/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { updateOrderStatus } from '@/services/supabase/orders/order.service';
-import { OrderStatus, isValidStatusTransition } from '@/types/order/order-status.enum';
+import { createClient } from '@/services/supabase/server';
 
 /**
  * PATCH /api/orders/[orderId]
  * Update order status
+ * Requires authentication and admin/manager role
  */
 export async function PATCH(
     request: NextRequest,
@@ -26,6 +27,42 @@ export async function PATCH(
             return NextResponse.json(
                 { error: 'Status is required' },
                 { status: 400 }
+            );
+        }
+
+        // SECURITY: Verify user is authenticated
+        const supabase = await createClient();
+        const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+        if (authError || !user) {
+            return NextResponse.json(
+                { error: 'Unauthorized - Please log in' },
+                { status: 401 }
+            );
+        }
+
+        // SECURITY: Verify user has admin/manager role
+        const { data: userProfile, error: profileError } = await supabase
+            .from('user_profiles')
+            .select('role_id, roles(role_name)')
+            .eq('user_id', user.id)
+            .single();
+
+        if (profileError || !userProfile) {
+            return NextResponse.json(
+                { error: 'User profile not found' },
+                { status: 403 }
+            );
+        }
+
+        // Check if user has admin or manager role
+        const roleName = (userProfile.roles as any)?.role_name?.toLowerCase();
+        const isAuthorized = roleName === 'admin' || roleName === 'manager';
+
+        if (!isAuthorized) {
+            return NextResponse.json(
+                { error: 'Forbidden - Only admins and managers can update order status' },
+                { status: 403 }
             );
         }
 

--- a/src/app/api/orders/[orderNumber]/route.ts
+++ b/src/app/api/orders/[orderNumber]/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getOrderByOrderNumber } from '@/services/supabase/orders/order.service';
+import { createClient } from '@/services/supabase/server';
 
 /**
  * GET /api/orders/[orderNumber]
  * Fetch order details by order number
+ * Requires authentication and verifies user owns the order
  */
 export async function GET(
     request: NextRequest,
@@ -19,6 +21,17 @@ export async function GET(
             );
         }
 
+        // SECURITY: Verify user is authenticated
+        const supabase = await createClient();
+        const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+        if (authError || !user) {
+            return NextResponse.json(
+                { error: 'Unauthorized - Please log in' },
+                { status: 401 }
+            );
+        }
+
         // Fetch order data
         const result = await getOrderByOrderNumber(orderNumber);
 
@@ -26,6 +39,14 @@ export async function GET(
             return NextResponse.json(
                 { error: 'Order not found' },
                 { status: 404 }
+            );
+        }
+
+        // SECURITY: Verify user owns this order
+        if (result.data.order.user_id !== user.id) {
+            return NextResponse.json(
+                { error: 'Forbidden - You do not have permission to view this order' },
+                { status: 403 }
             );
         }
 

--- a/src/app/order-confirmation/page.tsx
+++ b/src/app/order-confirmation/page.tsx
@@ -17,7 +17,7 @@ import {
     Loader2
 } from 'lucide-react';
 import Link from 'next/link';
-import Image from 'next/image';
+
 import { OrderStatus, PaymentStatus, getOrderStatusLabel, getOrderStatusColor } from '@/types/order/order-status.enum';
 
 // Animation variants
@@ -37,6 +37,46 @@ const itemVariants = {
     hidden: { opacity: 0, y: 20 },
     visible: { opacity: 1, y: 0 }
 };
+
+/**
+ * Get complete Tailwind class names for order status badge
+ * Note: Tailwind requires complete class names at build time - no dynamic interpolation!
+ */
+function getOrderStatusBadgeClasses(status: OrderStatus | string): string {
+    const statusLower = typeof status === 'string' ? status.toLowerCase() : status;
+
+    // Return complete class names (not dynamic) for Tailwind JIT compiler
+    const baseClasses = 'inline-block px-3 py-1 rounded-full text-sm font-medium';
+
+    switch (statusLower) {
+        case OrderStatus.PENDING:
+        case 'pending':
+            return `${baseClasses} bg-yellow-100 text-yellow-800`;
+        case OrderStatus.PAID:
+        case 'paid':
+            return `${baseClasses} bg-green-100 text-green-800`;
+        case OrderStatus.PROCESSING:
+        case 'processing':
+            return `${baseClasses} bg-blue-100 text-blue-800`;
+        case OrderStatus.SHIPPED:
+        case 'shipped':
+            return `${baseClasses} bg-purple-100 text-purple-800`;
+        case OrderStatus.DELIVERED:
+        case 'delivered':
+            return `${baseClasses} bg-green-100 text-green-800`;
+        case OrderStatus.CANCELLED:
+        case 'cancelled':
+            return `${baseClasses} bg-red-100 text-red-800`;
+        case OrderStatus.FAILED:
+        case 'failed':
+            return `${baseClasses} bg-red-100 text-red-800`;
+        case OrderStatus.REFUNDED:
+        case 'refunded':
+            return `${baseClasses} bg-gray-100 text-gray-800`;
+        default:
+            return `${baseClasses} bg-gray-100 text-gray-800`;
+    }
+}
 
 interface OrderData {
     order: {
@@ -208,7 +248,7 @@ function OrderConfirmationContent() {
 
                     <motion.div variants={itemVariants}>
                         <h2 className="text-sm text-gray-500">Order Status</h2>
-                        <span className={`inline-block px-3 py-1 rounded-full text-sm font-medium bg-${getOrderStatusColor(orderData.order.status as OrderStatus)}-100 text-${getOrderStatusColor(orderData.order.status as OrderStatus)}-800`}>
+                        <span className={getOrderStatusBadgeClasses(orderData.order.status as OrderStatus)}>
                             {getOrderStatusLabel(orderData.order.status as OrderStatus)}
                         </span>
                     </motion.div>


### PR DESCRIPTION
Secures the PATCH /api/orders/[orderId] endpoint by requiring authentication and restricting access to admin and manager roles. Secures the GET /api/orders/[orderNumber] endpoint by requiring authentication and ensuring the user owns the order. Refactors order status badge rendering in the order confirmation page to use a helper function with static Tailwind class names for compatibility with the JIT compiler.